### PR TITLE
Aggiunta draw, replace e  hide per il campo field

### DIFF
--- a/Class and Methods extension.R
+++ b/Class and Methods extension.R
@@ -1,0 +1,53 @@
+draw.field<- function(obj) {
+  library(DescTools)
+  par(mfrow = c(1, 1))
+  plot.new()
+
+    Canvas(16,16)
+    for(j in 1:length(obj$shape))
+    {
+      if(obj$visible[[j]]==1)
+      {
+        if(obj$num[[j]][1]==1){
+          DrawRegPolygon(x = obj$pos.x[[j]], y = obj$pos.y[[j]], rot = obj$rotation[[j]], 
+                         radius.x = obj$size.x[[j]], radius.y = obj$size.y[[j]], nv = obj$nv[[j]],
+                         lty=obj$lty[[j]],lwd=obj$lwd[[j]],col = obj$shade[[j]])
+        }else{
+          DrawCircle(x = obj$pos.x[[j]], y = obj$pos.y[[j]], 
+                     r.out = obj$size.x[[j]],r.in= obj$size.y[[j]], theta.1=obj$theta.1[[j]],
+                     theta.2=obj$theta.2[[j]], nv = obj$nv[[j]],
+                     lty=obj$lty[[j]],lwd=obj$lwd[[j]],col = obj$shade[[j]])
+          
+        }
+      }
+    }
+    
+  }
+
+
+replace <- function(obj,index,obj2) {
+  UseMethod("replace")
+}
+
+replace.field<-function(obj,index,obj2)
+{
+  for(i in 1:length(obj))
+  {
+    obj[[i]][[index]]<-obj2[[i]][[1]]
+  }
+  return(obj)
+}
+
+hide<- function(obj,index) {
+  UseMethod("hide")
+}
+
+hide.field<-function(obj,index="Full")
+{
+  if(any(index=="Full"))
+  {
+    index<-1:length(obj$shape)
+  }
+    obj$visible[index]<-integer(length(index))
+  return(obj)
+}

--- a/Class and Methods.R
+++ b/Class and Methods.R
@@ -236,10 +236,10 @@ apply.Raven_matrix <- function(obj,rules="HV") {
 }
 
 
-draw.Raven_matrix<- function(obj) {
+draw.Raven_matrix<- function(obj) { ###Definito Draw per i field si può semplificare questa
  
   library(DescTools)
-  par(mfrow = c(3, 3), mar = c(0.5, 6, 0.5, 2) + 0.1)
+  par(mfrow = c(3, 3), mar = c(0.5, 6, 0.5, 2) + .1, mai=c(.1,.1,.1,.1),oma=c(4,4,0.2,0.2) )
   
   squares <- paste0("Sq", 1:9)
   for (i in 1:length(squares))

--- a/Example_draw_field.R
+++ b/Example_draw_field.R
@@ -1,0 +1,75 @@
+current_path = rstudioapi::getActiveDocumentContext()$path
+setwd(dirname(current_path))
+cat("\014")
+rm(list = ls())
+
+source("Class and Methods.R")
+source("Class and Methods extension.R")
+source("Shapes_list.R")
+source("Rules_27102022.R")
+
+## Forme modificate ad Hoc per questi esempi
+
+lilth<-lily()
+s.lilth<-s.lily()
+for(i in 1:length(lilth$shape)) {
+  lilth$size.x[[i]] <-lilth$size.x[[i]]/2
+  lilth$size.y[[i]] <-lilth$size.y[[i]]/2
+  lilth$pos.y[[i]] <-lilth$pos.y[[i]]/2
+  lilth$pos.x[[i]] <-lilth$pos.x[[i]]/2
+  
+}
+
+s.lilth$size.x[[1]] <-s.lilth$size.x[[1]]/2
+s.lilth$size.y[[1]] <-s.lilth$size.y[[1]]/2
+s.lilth$pos.y[[1]] <-s.lilth$pos.y[[1]]/2
+s.lilth$pos.x[[1]] <-s.lilth$pos.x[[1]]/2
+
+for(i in 1:length(lilth$shape)) {
+  lilth$size.x[[i]] <-lilth$size.x[[i]]
+  lilth$size.y[[i]] <-lilth$size.y[[i]]
+  lilth$pos.y[[i]] <-lilth$pos.y[[i]]
+  lilth$pos.x[[i]] <-lilth$pos.x[[i]]
+  
+}
+
+s.lilth$size.x[[1]] <-s.lilth$size.x[[1]]
+s.lilth$size.y[[1]] <-s.lilth$size.y[[1]]
+s.lilth$pos.y[[1]] <-s.lilth$pos.y[[1]]
+s.lilth$pos.x[[1]] <-s.lilth$pos.x[[1]]
+
+
+xcros<- cross()
+xcros$lwd<-xcros$lwd[[1]]+4
+xcros$size.x<-xcros$size.x-4
+xcros$size.y<-xcros$size.y-4
+
+#### Esempio E01 
+
+M<-logic_rules(Raven(cof(hline(),square(s.x=3,s.y=3,rot = pi/2, shd="black"),dice(),vline())),"OR")
+draw(M)
+
+## Quadrato (3,3) tolgo la corretta dalla matrice
+Correct<-M$Sq9
+M1<-M
+M1$Sq9<-hide(M1$Sq9)
+
+
+##Funzione Draw estesa per il campo field
+draw(Correct)
+draw(M1)
+
+
+##Rimpiazzo  il quadrato con il Dot
+wrong1<-replace(Correct,2,dot())
+draw(wrong1)
+
+
+##Rimpiazzo  il quadrato con lilith
+wrong2<-replace(Correct,2,s.lilth)
+draw(wrong2)
+
+##Rimuovo la croce
+wrong3<-hide(wrong2,c(1,4))
+draw(wrong3)
+


### PR DESCRIPTION
**Draw** permette di printare i field in automatico

**Replace** permette di rimpiazzare un elemento in posizione "index" al interno di un field

**hide** mette non visibile le forme in posizione "index" dentro un campo. Se index viene lasciato vuoto tutto il campo viene messo non visibile.

Example_draw_field mostra qualche esempio di utilizzo  